### PR TITLE
Hotfix/entity disciplina

### DIFF
--- a/src/main/java/com/ic045/sistemaacademico/controller/DisciplinaController.java
+++ b/src/main/java/com/ic045/sistemaacademico/controller/DisciplinaController.java
@@ -47,7 +47,7 @@ public class DisciplinaController {
 		Curso curso = new Curso();
 		curso.setId(insertDisciplina.curso());
 		Disciplina disciplina = new Disciplina(null, curso, insertDisciplina.nome(),
-				null, insertDisciplina.ementa(), insertDisciplina.preRequisitos(),
+				"", insertDisciplina.ementa(), insertDisciplina.preRequisitos(),
 				insertDisciplina.area().name(), insertDisciplina.observacao(), insertDisciplina.chTotal(), insertDisciplina.chTeorica(),
 				insertDisciplina.chPratica(), insertDisciplina.bibliografia());
 

--- a/src/main/java/com/ic045/sistemaacademico/controller/DisciplinaController.java
+++ b/src/main/java/com/ic045/sistemaacademico/controller/DisciplinaController.java
@@ -59,7 +59,7 @@ public class DisciplinaController {
 			Curso curso = new Curso();
 			curso.setId(updatedDisciplina.curso());
 
-			Disciplina updatedDisciplinaModel = new Disciplina(null, curso, updatedDisciplina.nome(), null, updatedDisciplina.ementa(), updatedDisciplina.preRequisitos(),
+			Disciplina updatedDisciplinaModel = new Disciplina(null, curso, updatedDisciplina.nome(), "", updatedDisciplina.ementa(), updatedDisciplina.preRequisitos(),
 							updatedDisciplina.area().name(), updatedDisciplina.observacao(), updatedDisciplina.chTotal(),
 							updatedDisciplina.chTeorica(), updatedDisciplina.chPratica(), updatedDisciplina.bibliografia());
 

--- a/src/main/java/com/ic045/sistemaacademico/domain/models/Disciplina.java
+++ b/src/main/java/com/ic045/sistemaacademico/domain/models/Disciplina.java
@@ -34,6 +34,7 @@ public class Disciplina {
 	@NonNull
 	private String nome;
 
+	@NonNull
 	private String codigo;
 
 	@NonNull

--- a/src/main/java/com/ic045/sistemaacademico/services/DisciplinaService.java
+++ b/src/main/java/com/ic045/sistemaacademico/services/DisciplinaService.java
@@ -68,7 +68,6 @@ public class DisciplinaService {
             existingDisciplina.setNome(updatedDisciplina.getNome());
             existingDisciplina.setEmenta(updatedDisciplina.getEmenta());
             existingDisciplina.setPreRequisitos(updatedDisciplina.getPreRequisitos());
-            existingDisciplina.setArea(updatedDisciplina.getArea());
             existingDisciplina.setObservacao(updatedDisciplina.getObservacao());
             existingDisciplina.setChTotal(updatedDisciplina.getChTotal());
             existingDisciplina.setChTeorica(updatedDisciplina.getChTeorica());


### PR DESCRIPTION
Define atributo código da entidade Disciplina como não nulo, alinhando com o modelo definido em banco.

Ajusta chamadas ao construtor da classe passando parâmetro não nulo.

Modifica rota de update disciplina para não permitir mudança na área da disciplina.